### PR TITLE
new tool hrtimersnoop

### DIFF
--- a/TOOLS.md
+++ b/TOOLS.md
@@ -6,6 +6,7 @@ process of migrating tools from the
 comprehensive list is available 
 [here](https://github.com/bpftrace/bpftrace/blob/master/README.md#tools).
 
+- [hrtimersnoop](hrtimersnoop): High-resolution timer latency tracing.
 - [mqsnoop](https://github.com/bpftrace/user-tools/tree/master/mqsnoop):
 Trace POSIX message queue send.
 - [nfcttrace](https://github.com/bpftrace/user-tools/tree/master/nfcttrace): 

--- a/hrtimersnoop/README.md
+++ b/hrtimersnoop/README.md
@@ -1,0 +1,24 @@
+# hrtimersnoop
+
+hrtimersnoop attaches to the hrtimer_expire_entry and hrtimer_expire_exit
+tracepoints, measuring both the delay in timer expiration and the duration of
+timer handler execution. Measurements exceeding at least one threshold are
+printed.
+
+USAGE: hrtimersnoop.bt \[delay threshold in microseconds\] \[duration threshold in microseconds\]
+
+## Output
+
+```
+# ./hrtimersnoop.bt 100 10
+Attaching 4 probes...
+Tracing high-resolution timer delay and duration in microseconds. Ctrl-C to end.
+TIME            HANDLER                           DELAY DURATION
+11:37:32.804113 tick_sched_timer                      0       22
+11:37:32.804148 tick_sched_timer                     45       13
+11:37:32.804150 tick_sched_timer                     43       15
+11:37:32.804152 tick_sched_timer                     45       16
+11:37:32.804153 tick_sched_timer                     43       14
+11:37:32.805093 hrtimer_wakeup                       86       10
+11:37:32.805148 intel_uncore_fw_release_timer       966        1
+```

--- a/hrtimersnoop/hrtimersnoop.bt
+++ b/hrtimersnoop/hrtimersnoop.bt
@@ -1,0 +1,53 @@
+#!/usr/bin/env bpftrace
+
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+/*
+ * hrtimersnoop.bt   High-resolution timer latency tracing tool.
+ *
+ * USAGE: hrtimersnoop.bt [delay threshold in microseconds] [duration threshold in microseconds]
+ *
+ * Copyright 2024 Red Hat, Inc., Costa Shulyupin
+ *
+ */
+
+BEGIN
+{
+	printf("Tracing high-resolution timer delay and duration in microseconds. Ctrl-C to end.\n");
+	printf("%-15s %-30s %8s %8s\n", "TIME", "HANDLER", "DELAY", "DURATION");
+}
+
+tracepoint:timer:hrtimer_expire_entry
+{
+	$expires = ((struct hrtimer*)args.hrtimer)->_softexpires;
+	if ($expires > 1 && args.now >= $expires) {
+		@delay[args.hrtimer] = ((uint64)args.now - (uint64)$expires) / 1000;
+	}
+	@start[args.hrtimer] = nsecs;
+	@function[args.hrtimer] = args.function;
+}
+
+tracepoint:timer:hrtimer_expire_exit
+/@function[args.hrtimer]/
+{
+	if (@start[args.hrtimer]) {
+		$duration = (nsecs - @start[args.hrtimer]) / 1000;
+	}
+	if (@delay[args.hrtimer] >= (uint64)$1 || $duration >= (uint64)$2) {
+		printf("%-15s %-30s %8ld %8ld\n",
+			strftime("%H:%M:%S.%f", nsecs),
+			ksym(@function[args.hrtimer]),
+			@delay[args.hrtimer],
+			$duration);
+	}
+	delete(@start[args.hrtimer]);
+	delete(@function[args.hrtimer]);
+	delete(@delay[args.hrtimer]);
+}
+
+END
+{
+	clear(@start);
+	clear(@function);
+	clear(@delay);
+}


### PR DESCRIPTION
The tool attaches to timer tracepoints `hrtimer_expire_entry`, `hrtimer_expire_exit` and measures delay of timer expiration and duration of timer handler execution.