### PR TITLE
signal: Add new tool sigsnoop

### DIFF
--- a/signal/sigsnoop.bt
+++ b/signal/sigsnoop.bt
@@ -1,0 +1,102 @@
+#!/bin/env bpftrace
+// SPDX-License-Identifier: GPL-2.0-or-later
+/**
+ * sigsnoop.bt - Trace standard and real-time signals.
+ *               For Linux, uses bpftrace and eBPF.
+ *
+ * This is a bpftrace version of the bcc libbpf-tools/sigsnoop of the same name.
+ *
+ * USAGE: sigsnoop.bt
+ *
+ * Copyright (C) 2024 CESTC, Co.
+ */
+#ifndef BPFTRACE_HAVE_BTF
+#include <linux/sched.h>
+#endif
+
+BEGIN
+{
+	@SIG_STR[1] = "SIGHUP";
+	@SIG_STR[2] = "SIGINT";
+	@SIG_STR[3] = "SIGQUIT";
+	@SIG_STR[4] = "SIGILL";
+	@SIG_STR[5] = "SIGTRAP";
+	@SIG_STR[6] = "SIGABRT";
+	@SIG_STR[7] = "SIGBUS";
+	@SIG_STR[8] = "SIGFPE";
+	@SIG_STR[9] = "SIGKILL";
+	@SIG_STR[10] = "SIGUSR1";
+	@SIG_STR[11] = "SIGSEGV";
+	@SIG_STR[12] = "SIGUSR2";
+	@SIG_STR[13] = "SIGPIPE";
+	@SIG_STR[14] = "SIGALRM";
+	@SIG_STR[15] = "SIGTERM";
+	@SIG_STR[16] = "SIGSTKFLT";
+	@SIG_STR[17] = "SIGCHLD";
+	@SIG_STR[18] = "SIGCONT";
+	@SIG_STR[19] = "SIGSTOP";
+	@SIG_STR[20] = "SIGTSTP";
+	@SIG_STR[21] = "SIGTTIN";
+	@SIG_STR[22] = "SIGTTOU";
+	@SIG_STR[23] = "SIGURG";
+	@SIG_STR[24] = "SIGXCPU";
+	@SIG_STR[25] = "SIGXFSZ";
+	@SIG_STR[26] = "SIGVTALRM";
+	@SIG_STR[27] = "SIGPROF";
+	@SIG_STR[28] = "SIGWINCH";
+	@SIG_STR[29] = "SIGIO";
+	@SIG_STR[30] = "SIGPWR";
+	@SIG_STR[31] = "SIGSYS";
+
+	printf("Tracing signals, hit ctrl-c to end.\n");
+	printf("%-8s %-8s %-16s %-8s %-8s\n",
+		"TIME", "PID", "COMM", "TPID", "SIG");
+}
+
+tracepoint:syscalls:sys_enter_kill,
+tracepoint:syscalls:sys_enter_tkill,
+tracepoint:syscalls:sys_enter_tgkill
+{
+	@pids[tid] = args->pid;
+	@sigs[tid] = args->sig;
+}
+
+tracepoint:syscalls:sys_exit_kill,
+tracepoint:syscalls:sys_exit_tkill,
+tracepoint:syscalls:sys_exit_tgkill
+/ @pids[tid] && @sigs[tid] /
+{
+	$pid = @pids[tid];
+	$sig = @sigs[tid];
+
+	time("%H:%M:%S ");
+	if (@SIG_STR[$sig] == "") {
+		printf("%-8d %-16s %-8d %-8d\n", pid, comm, $pid, $sig);
+	} else {
+		printf("%-8d %-16s %-8d %-8s\n", pid, comm, $pid, @SIG_STR[$sig]);
+	}
+
+	delete(@pids[tid]);
+	delete(@sigs[tid]);
+}
+
+tracepoint:signal:signal_generate
+{
+	$pid = args->pid;
+	$sig = args->sig;
+
+	time("%H:%M:%S ");
+	if (@SIG_STR[$sig] == "") {
+		printf("%-8d %-16s %-8d %-8d\n", pid, comm, $pid, $sig);
+	} else {
+		printf("%-8d %-16s %-8d %-8s\n", pid, comm, $pid, @SIG_STR[$sig]);
+	}
+}
+
+END
+{
+	clear(@pids);
+	clear(@sigs);
+	clear(@SIG_STR);
+	printf("Bye.\n");
+}

--- a/signal/sigsnoop_example.txt
+++ b/signal/sigsnoop_example.txt
@@ -1,0 +1,13 @@
+Demonstration of sigsnoop
+
+$ sudo ./sigsnoop.bt
+Attaching 9 probes...
+Tracing signals, hit ctrl-c to end.
+TIME     PID      COMM             TPID     SIG
+09:42:33 214863   locate           214860   SIGCHLD
+09:42:33 214866   locate           214860   SIGCHLD
+09:42:33 214862   rpm              214861   SIGCHLD
+09:42:33 214868   rpm              214861   SIGCHLD
+09:42:33 214869   rpm              214861   SIGCHLD
+09:42:33 214870   uname            214861   SIGCHLD
+09:42:34 214879   rpm              214874   SIGCHLD


### PR DESCRIPTION
This tool trace standard and real-time signals.

```
    $ sudo ./sigsnoop.bt
    Attaching 9 probes...
    Tracing signals, hit ctrl-c to end.
    TIME     PID      COMM             TPID     SIG
    09:48:14 1469     Xorg             1469     SIGALRM
    09:48:16 0        swapper/9        2146     34
```
