### PR TITLE
sched: Add numasched tool

### DIFF
--- a/TOOLS.md
+++ b/TOOLS.md
@@ -6,6 +6,8 @@ process of migrating tools from the
 comprehensive list is available 
 [here](https://github.com/bpftrace/bpftrace/blob/master/README.md#tools).
 
+- [numasched](https://github.com/bpftrace/user-tools/tree/master/numasched):
+Trace scheduling of system processes between NUMA nodes.
 - [sigsnoop](https://github.com/bpftrace/user-tools/tree/master/signal): 
 Trace standard and real-time signals.
 

--- a/numasched/README.md
+++ b/numasched/README.md
@@ -1,0 +1,68 @@
+# numasched
+
+The scheduling of system processes between NUMA nodes is tracked.
+This is done by instrumenting sched:sched_switch tracepoints and
+numaid builtin.
+
+
+## Output
+
+NUMA Information:
+
+```
+  $ numactl --hardware
+  available: 4 nodes (0-3)
+  node 0 cpus: 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23
+  node 0 size: 97373 MB
+  node 0 free: 1756 MB
+  node 1 cpus: 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39 40 41 42 43 44 45 46 47
+  node 1 size: 98192 MB
+  node 1 free: 1269 MB
+  node 2 cpus: 48 49 50 51 52 53 54 55 56 57 58 59 60 61 62 63 64 65 66 67 68 69 70 71
+  node 2 size: 98192 MB
+  node 2 free: 4811 MB
+  node 3 cpus: 72 73 74 75 76 77 78 79 80 81 82 83 84 85 86 87 88 89 90 91 92 93 94 95
+  node 3 size: 98135 MB
+  node 3 free: 1617 MB
+  node distances:
+  node   0   1   2   3
+    0:  10  12  20  22
+    1:  12  10  22  24
+    2:  20  22  10  12
+    3:  22  24  12  10
+```
+
+
+Terminal 1, start a task running on NUMA0:
+
+```
+  $ taskset -c 1 yes >/dev/null
+```
+
+Terminal 2, start tracing:
+
+```
+  $ sudo ./numasched.bt
+```
+
+
+Terminal 3
+
+```
+  # taskset 'yes' task to NUMA1(cpu=24):
+  $ taskset -p 0x1000000 $(pidof yes)
+
+  # taskset 'yes' task to NUMA2(cpu=48):
+  $ taskset -p 0x1000000000000 $(pidof yes)
+```
+
+Then, Terminal 2 shows:
+
+```
+  $ sudo ./numasched.bt
+  Attaching 3 probes...
+  Tracing task numa switch.
+  TIME     PID      TID      SRC_NID     DST_NID  COMM
+  16:19:08 915188   915188   0        -> 1        yes
+  16:19:14 915188   915188   1        -> 2        yes
+```

--- a/numasched/numasched.bt
+++ b/numasched/numasched.bt
@@ -1,0 +1,45 @@
+#!/bin/env bpftrace
+// SPDX-License-Identifier: GPL-2.0-or-later
+/*
+ * numasched	Trace task switch numa
+ *		For Linux, uses bpftrace and eBPF.
+ *
+ * This tool requires a kernel version >= 5.8.
+ *
+ * USAGE: numasched.bt
+ *
+ * Copyright 2022 CESTC, Co.
+ */
+BEGIN
+{
+	printf("Tracing task numa switch.\n");
+	printf("%-8s %-8s %-8s %-8s    %-8s %-8s\n",
+	       "TIME", "PID", "TID", "SRC_NID", "DST_NID", "COMM");
+}
+
+tracepoint:sched:sched_switch
+/ pid != 0 /
+{
+	$old_nid = @nid_map[tid];
+	$new_nid = numaid;
+
+	if ($old_nid != $new_nid && @mark_first[tid] == 1) {
+		time("%H:%M:%S ");
+		printf("%-8d %-8d %-8d -> %-8d %s\n",
+			pid, tid, $old_nid, $new_nid, comm);
+	}
+
+	@nid_map[tid] = $new_nid;
+
+	/* If the first time you run the above code, $old_nid equals 0,
+	 * then $old_nid is easily not equal to $new_nid, so we skip the
+	 * first time and want the @nid_map to become a valid numa */
+	@mark_first[tid] = 1;
+}
+
+END
+{
+	clear(@nid_map);
+	clear(@mark_first);
+}
+


### PR DESCRIPTION
Too much schedule between NUMA could cause bad performance, numasched tool could tracing NUMA sched switch. For example:

Hardware information:

    $ numactl --hardware
    available: 4 nodes (0-3)
    node 0 cpus: 0
    node 0 size: 1006 MB
    node 0 free: 241 MB
    node 1 cpus: 1
    node 1 size: 924 MB
    node 1 free: 47 MB
    node 2 cpus: 2
    node 2 size: 1007 MB
    node 2 free: 61 MB
    node 3 cpus: 3
    node 3 size: 956 MB
    node 3 free: 122 MB
    node distances:
    node   0   1   2   3
      0:  10  20  20  20
      1:  20  10  20  20
      2:  20  20  10  20
      3:  20  20  20  10

NUMA sched switch tracing:

    $ sudo ./numasched.bt
    Attaching 3 probes...
    Tracing task numa switch.
    TIME     PID      TID      SRC_NID     DST_NID  COMM
    10:19:30 41       41       1        -> 2        kworker/u10:0
    10:19:30 722      722      3        -> 0        jbd2/vda2-8
    10:19:30 41       41       2        -> 1        kworker/u10:0
    10:19:30 47       47       1        -> 0        kauditd
    10:19:30 850      860      2        -> 0        gdbus
    10:19:30 1184     1184     2        -> 0        gnome-shell
    10:19:30 819      819      0        -> 2        dbus-broker
    10:19:30 849      849      0        -> 2        systemd-machine
    10:19:30 618      618      0        -> 3        systemd-journal
    10:19:30 1684     1684     0        -> 3        systemd-userwor
    ...

This tool based on bpftrace [0] numaid [1] builtin.

[0] https://github.com/bpftrace/bpftrace.git
[1] bpftrace commit 121f73df1cb8 ("Add builtin 'numaid'")