### PR TITLE
doc: use dash (minus) instead of colon

### DIFF
--- a/TOOLS.md
+++ b/TOOLS.md
@@ -6,13 +6,13 @@ process of migrating tools from the
 comprehensive list is available 
 [here](https://github.com/bpftrace/bpftrace/blob/master/README.md#tools).
 
-- [hrtimersnoop](hrtimersnoop): High-resolution timer latency tracing.
-- [mqsnoop](https://github.com/bpftrace/user-tools/tree/master/mqsnoop):
+- [hrtimersnoop](hrtimersnoop) - High-resolution timer latency tracing.
+- [mqsnoop](https://github.com/bpftrace/user-tools/tree/master/mqsnoop) -
 Trace POSIX message queue send.
-- [nfcttrace](https://github.com/bpftrace/user-tools/tree/master/nfcttrace): 
+- [nfcttrace](https://github.com/bpftrace/user-tools/tree/master/nfcttrace) -
 Show entries about TCP&UDP in nf_conntrack.
-- [numasched](https://github.com/bpftrace/user-tools/tree/master/numasched):
+- [numasched](https://github.com/bpftrace/user-tools/tree/master/numasched) -
 Trace scheduling of system processes between NUMA nodes.
-- [sigsnoop](https://github.com/bpftrace/user-tools/tree/master/sigsnoop):
+- [sigsnoop](https://github.com/bpftrace/user-tools/tree/master/sigsnoop) -
 Trace standard and real-time signals.
-- [wakesnoop](wakesnoop): Task wakeup latency tracing.
+- [wakesnoop](wakesnoop) - Task wakeup latency tracing.


### PR DESCRIPTION
Quote:

The colon is a powerful punctuation mark and should be used sparingly.

https://blog.wordvice.com/when-to-use-commas-colons-semicolons-and-dashes/

For example, dash (minus) is used in man pages:
https://man7.org/linux/man-pages/dir_all_by_section.html