### PR TITLE
signoop: Support real-time signals

### DIFF
--- a/sigsnoop/README.md
+++ b/sigsnoop/README.md
@@ -5,17 +5,19 @@ This is done by instrumenting signal/signal_generate tracepoints.
 
 ## Output
 
+```
 $ sudo ./sigsnoop.bt
 Attaching 9 probes...
 Tracing signals, hit ctrl-c to end.
 TIME     PID      COMM             TPID     SIG
-09:42:33 214863   locate           214860   SIGCHLD
-09:42:33 214866   locate           214860   SIGCHLD
-09:42:33 214862   rpm              214861   SIGCHLD
-09:42:33 214868   rpm              214861   SIGCHLD
-09:42:33 214869   rpm              214861   SIGCHLD
-09:42:33 214870   uname            214861   SIGCHLD
-09:42:34 214879   rpm              214874   SIGCHLD
+08:25:28 195973   vte-urlencode-c  194760   SIGCHLD
+08:25:29 195974   ls               194760   SIGCHLD
+08:25:29 195975   vte-urlencode-c  194760   SIGCHLD
+08:25:29 1847     Xorg             1847     SIGALRM
+08:25:31 0        swapper/3        2594     SIGNAL-34
+08:25:31 1847     Xorg             1847     SIGALRM
+^CBye.
+```
 
-The first line shows that pid 214863 (locate thread) delivered a SIGCHLD 
-signal to pid 214860 (TPID = the target pid).
+The first line shows that pid 195973 (locate thread) delivered a SIGCHLD
+signal to pid 194760 (TPID = the target pid).

--- a/sigsnoop/sigsnoop.bt
+++ b/sigsnoop/sigsnoop.bt
@@ -47,6 +47,39 @@ BEGIN
 	@SIG_STR[29] = "SIGIO";
 	@SIG_STR[30] = "SIGPWR";
 	@SIG_STR[31] = "SIGSYS";
+	@SIG_STR[32] = "SIGNAL-32"; /* SIGRTMIN in kernel */
+	@SIG_STR[33] = "SIGNAL-33";
+	@SIG_STR[34] = "SIGNAL-34";
+	@SIG_STR[35] = "SIGNAL-35";
+	@SIG_STR[36] = "SIGNAL-36";
+	@SIG_STR[37] = "SIGNAL-37";
+	@SIG_STR[38] = "SIGNAL-38";
+	@SIG_STR[39] = "SIGNAL-39";
+	@SIG_STR[40] = "SIGNAL-40";
+	@SIG_STR[41] = "SIGNAL-41";
+	@SIG_STR[42] = "SIGNAL-42";
+	@SIG_STR[43] = "SIGNAL-43";
+	@SIG_STR[44] = "SIGNAL-44";
+	@SIG_STR[45] = "SIGNAL-45";
+	@SIG_STR[46] = "SIGNAL-46";
+	@SIG_STR[47] = "SIGNAL-47";
+	@SIG_STR[48] = "SIGNAL-48";
+	@SIG_STR[49] = "SIGNAL-49";
+	@SIG_STR[50] = "SIGNAL-50";
+	@SIG_STR[51] = "SIGNAL-51";
+	@SIG_STR[52] = "SIGNAL-52";
+	@SIG_STR[53] = "SIGNAL-53";
+	@SIG_STR[54] = "SIGNAL-54";
+	@SIG_STR[55] = "SIGNAL-55";
+	@SIG_STR[56] = "SIGNAL-56";
+	@SIG_STR[57] = "SIGNAL-57";
+	@SIG_STR[58] = "SIGNAL-58";
+	@SIG_STR[59] = "SIGNAL-59";
+	@SIG_STR[60] = "SIGNAL-60";
+	@SIG_STR[61] = "SIGNAL-61";
+	@SIG_STR[62] = "SIGNAL-62";
+	@SIG_STR[63] = "SIGNAL-63";
+	@SIG_STR[64] = "SIGNAL-64"; /* SIGRTMAX */
 
 	printf("Tracing signals, hit ctrl-c to end.\n");
 	printf("%-8s %-8s %-16s %-8s %-8s\n",


### PR DESCRIPTION
Like bcc sigsnoop did [1][2], support SIGRTMIN-SIGRTMAX.

Link: https://github.com/iovisor/bcc/commit/62178b93ae5b [1]
Link: https://github.com/iovisor/bcc/pull/5216 [2]