### PR TITLE
Add new tool pagefaultlatency

### DIFF
--- a/pagefaultlatency/README.md
+++ b/pagefaultlatency/README.md
@@ -1,0 +1,51 @@
+# pagefaultlatency
+
+Pagefaults are a common exception in Linux kernel. Their handling efficiency
+significantly impacts the performance of programs with frequent memory accesses.
+This tool helps assess pagefault latency when executing specific programs.
+
+`pagefaultlatency.bt` traces pagefaults by instrumenting `kprobe:handle_mm_fault`.
+Its output shows:
+- The number of pagefaults generated and the latency of each pagefault
+- The average pagefault latency
+- A pagefault latency histogram
+
+USAGE: `pagefaultlatency.bt [thread_name]`
+
+## Output
+
+1. Open console no.1
+
+```shell
+$ sudo ./pagefaultlatency.bt ls
+Attaching 4 probes...
+proc=ls
+```
+
+2. Open console no.2
+
+```shell
+$ ls -l
+```
+
+3. The console no.1 outputs the average pagefault time. Press Ctrl+C to output
+the latency histogram.
+
+```shell
+[000] latency=11637 ns
+[001] latency=5921 ns
+[002] latency=3471 ns
+...
+[408] latency=1429 ns
+[409] latency=2041 ns
+[410] latency=1429 ns
+^CAverage page fault time for comm[ps]: 2765 ns [cnt=411]
+
+@usecs:
+[0]                   45 |@@@@@@@@@@@@                                        |
+[1]                  191 |@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@|
+[2, 4)               126 |@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@                  |
+[4, 8)                37 |@@@@@@@@@@                                          |
+[8, 16)               10 |@@                                                  |
+[16, 32)               2 |                                                    |
+```

--- a/pagefaultlatency/pagefaultlatency.bt
+++ b/pagefaultlatency/pagefaultlatency.bt
@@ -1,0 +1,52 @@
+#!/usr/bin/bpftrace
+
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+/*
+ * pagefaultlatency.bt    Pagefault latency tracing tool.
+ *
+ * USAGE: pagefaultlatency.bt [thread_name]
+ */
+
+BEGIN
+{
+    if ($# == 1) {
+        @proc = str($1);
+        printf("Tracing pagefault latency for comm[%s]\n", @proc);
+    } else {
+        printf("No command specified!\n");
+        exit();
+    }
+}
+
+kprobe:handle_mm_fault
+/comm == @proc/
+{
+    @start[tid] = nsecs();
+}
+
+kretprobe:handle_mm_fault
+/@start[tid]/
+{
+    @usecs = hist((nsecs - @start[tid]) / 1000);
+    $latency = nsecs() - @start[tid];
+    delete(@start[tid]);
+    printf("[%03d] latency=%d ns\n", @count, $latency);
+    @duration = sum($latency);
+    @count += 1;
+}
+
+END
+{
+    if (@count > 0) {
+        $avg = @duration / @count;
+        printf("Average pagefault time for comm[%s]: %d ns [cnt=%d]\n", @proc, $avg, @count);
+    } else {
+        printf("No pagefault recorded for comm[%s].\n", @proc);
+    }
+
+    clear(@proc);
+    clear(@count);
+    clear(@duration);
+    clear(@start);
+}


### PR DESCRIPTION
This tool tracing pagefault latency for specific command by instrumenting kprobe:handle_mm_fault.