### PR TITLE
slableaktracker: Track down sources of slab leaks

### DIFF
--- a/TOOLS.md
+++ b/TOOLS.md
@@ -11,4 +11,5 @@ comprehensive list is available
 - [nfcttrace](nfcttrace) - Show entries about TCP&UDP in nf_conntrack.
 - [numasched](numasched) - Trace scheduling of system processes between NUMA nodes.
 - [sigsnoop](sigsnoop) - Trace standard and real-time signals.
+- [slableaktracker](slableaktracker) - Track down slab leaks.
 - [wakesnoop](wakesnoop) - Task wakeup latency tracing.

--- a/slableaktracker/README.md
+++ b/slableaktracker/README.md
@@ -1,0 +1,51 @@
+# slableaktracker
+
+Tracks outstanding slab object allocations within a single slab. Useful for tracking down the source of slab leaks.
+On slab object allocation, creates a record of allocation information and deletes that record when the object is freed. Will terminate early if 65536 allocations are recorded.
+
+## Output
+
+```
+# ./slableaktracker.bt dentry
+Attaching 4 probes...
+Starting slab user tracking for slab dentry.
+^C@remaining_allocs[1804, bpftrace, 
+	ffffffffb1a96ecf kmem_cache_alloc_lru_noprof+655
+	ffffffffb1a96ecf kmem_cache_alloc_lru_noprof+655
+	ffffffffb1b4a4bd __d_alloc+45
+	ffffffffb1b4d67e d_alloc_pseudo+14
+	ffffffffb1b29a4a alloc_file_pseudo+106
+	ffffffffb1ba124b __anon_inode_getfile+123
+	ffffffffb19cbd17 __do_sys_perf_event_open+2279
+	ffffffffb254387c do_syscall_64+124
+	ffffffffb140012f entry_SYSCALL_64_after_hwframe+118
+]: 1
+@remaining_allocs[1813, find, 
+	ffffffffb1a96ecf kmem_cache_alloc_lru_noprof+655
+	ffffffffb1a96ecf kmem_cache_alloc_lru_noprof+655
+	ffffffffb1b4a4bd __d_alloc+45
+	ffffffffb1b4d7fd d_alloc_parallel+61
+	ffffffffb1bf2498 proc_fill_cache+232
+	ffffffffb1bf3363 proc_pid_readdir+339
+	ffffffffb1b45a0a iterate_dir+170
+	ffffffffb1b4607b __x64_sys_getdents64+123
+	ffffffffb254387c do_syscall_64+124
+	ffffffffb140012f entry_SYSCALL_64_after_hwframe+118
+]: 4
+...
+@remaining_allocs[1813, find, 
+	ffffffffb1a96ecf kmem_cache_alloc_lru_noprof+655
+	ffffffffb1a96ecf kmem_cache_alloc_lru_noprof+655
+	ffffffffb1b4a4bd __d_alloc+45
+	ffffffffb1b4d7fd d_alloc_parallel+61
+	ffffffffb1bf2498 proc_fill_cache+232
+	ffffffffb1bf293b proc_map_files_readdir+1035
+	ffffffffb1b45a0a iterate_dir+170
+	ffffffffb1b4607b __x64_sys_getdents64+123
+	ffffffffb254387c do_syscall_64+124
+	ffffffffb140012f entry_SYSCALL_64_after_hwframe+118
+]: 592
+Remaining dentry object count: 1486
+```
+
+Each "stanza" is the count of unique combinations of the process and pid the allocation occurred in and the code path taken to allocate the object. For example, the last stanza indicates 592 `dentry` slab objects were allocated by the `find` command with PID 1813. It allocated that many because the code path needed to iterate a directory in `/proc` and store the dentry object found. A total of 1486 dentry slab objects were not freed before the script terminated.

--- a/slableaktracker/slableaktracker.bt
+++ b/slableaktracker/slableaktracker.bt
@@ -1,0 +1,50 @@
+#!/bin/env bpftrace
+// SPDX-License-Identifier: GPL-2.0-or-later
+/*
+ * slableaktracker.bt - Keeps track of to-be-freed slab objects
+ *                      from a specified slab cache. 
+ *
+ * USAGE: ./slableaktracker.bt <slab>
+ *
+ * Copyright (c) 2025 Charles Haithcock.
+ *
+ * 26-Oct-2025  Charles Haithcock  created this.
+ */
+
+config = {
+	print_maps_on_exit=0;
+	max_map_keys=65536;
+}
+
+BEGIN {
+	if ($# != 1) {
+		printf("\nERROR: Missing slab parameter to track.\n");
+		printf("USAGE: ./slableaktracker.bt <slab>\n");
+		exit(22); /* EINVAL */
+	}
+	printf("Starting slab user tracking for slab %s.\n", str($1));
+}
+
+tracepoint:kmem:kmem_cache_alloc /str(args.name) == str($1)/ {
+	if (len(@tracks) == 65536) {
+		exit();
+	}
+	@tracks[args.ptr] = (pid, comm, kstack(perf));
+}
+
+tracepoint:kmem:kmem_cache_free /str(args.name) == str($1)/ {
+	delete(@tracks, args.ptr);
+}
+
+END {
+	for ($track : @tracks) {
+		/* Key on kernel stacks */
+		@remaining_allocs[$track.1] = count();
+	}
+	print(@remaining_allocs);
+	printf("Remaining %s object count: %d\n", str($1), len(@tracks));
+	if (len(@tracks) == 65536) {
+		printf("Exiting early due to slab allocation information storage being full\n");
+	}
+	clear(@tracks);
+}


### PR DESCRIPTION
The kernel recently allowed for printing the name of a slab cache on the static tracepoint, `kmem:kmem_cache_alloc`. Now that both the alloc and corresponding `kmem:kmem_cache_free` static tracepoints provide the name of the slab cache, leverage these to track down slab leaks in a slab cache.